### PR TITLE
Use "noq" for ALPN identifier

### DIFF
--- a/draft-dai-netconf-over-quic.xml
+++ b/draft-dai-netconf-over-quic.xml
@@ -207,7 +207,7 @@ Layer                 Example
       <t>The "noq" string identifies NETCONFoQUIC:</t>
       <ul>
         <li>Protocol: NETCONFoQUIC</li>
-        <li>Identification Sequence: 0x4e 0x6f 0x51 ("NoQ")</li>
+        <li>Identification Sequence: 0x6e 0x6f 0x71 ("noq")</li>
         <li>Specification: This document</li>
       </ul>
       <t>In addition, it is requested for IANA to reserve a UDP port TBD for 'NETCONF over QUIC'.</t>


### PR DESCRIPTION
The IANA Considerations section mentioned both "noq" and "NoQ" as identification sequence.

Use the consistent identification sequence: 0x6e 0x6f 0x71 ("noq")